### PR TITLE
Update Venstar_Colortouch.pm

### DIFF
--- a/lib/Venstar_Colortouch.pm
+++ b/lib/Venstar_Colortouch.pm
@@ -473,7 +473,7 @@ sub _get_JSON_data {
             my $isSuccessResponse = $responseCode < 400;
             $self->{updating} = 0;
             if ( !$isSuccessResponse ) {
-                main::print_log( "[Venstar Colortouch:" . $self->{data}->{name} . "] Warning, failed to get data. Response code $responseCode" );
+                main::print_log( "[Venstar Colortouch: (" . $self->{host} . ")] Warning, failed to get data. Response code $responseCode" );
                 print "Venstar. status=" . $self->{status};
                 if ( defined $self->{child_object}->{comm} ) {
                     print " Tracker defined\n";


### PR DESCRIPTION
If there's an error gathering data, then $self->{data}->{name} will not be defined:
Use of uninitialized value in concatenation (.) or string at /opt/misterhouse/fork_pmantis/bin/../lib/Venstar_Colortouch.pm line 398.